### PR TITLE
Improve reliability when operator units are churned

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -55,9 +55,15 @@ class PrometheusScrapeConfigCharm(CharmBase):
         )
 
         # When a new consumer of the metrics-endpoint relation is related,
-        # pass it all the current scrape jobs
+        # pass it all the current scrape jobs. We register to both the relation
+        # being created and joined, because relation_created is not reliably sent
+        # over unit recreation.
         self.framework.observe(
             self.on[self._prometheus_relation_name].relation_created,
+            self._set_jobs_to_new_downstream,
+        )
+        self.framework.observe(
+            self.on[self._prometheus_relation_name].relation_joined,
             self._set_jobs_to_new_downstream,
         )
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -157,7 +157,11 @@ class TestCharm(unittest.TestCase):
         )
 
         downstream1_rel_id = self.harness.add_relation("metrics-endpoint", "prometheus-k8s-1")
+        self.harness.add_relation_unit(downstream1_rel_id, "prometheus-k8s-2/0")
+
         downstream2_rel_id = self.harness.add_relation("metrics-endpoint", "prometheus-k8s-2")
+        self.harness.add_relation_unit(downstream2_rel_id, "prometheus-k8s-2/1")
+
         # Check that is does not really matter whether we have units
         # on Prometheus side
 


### PR DESCRIPTION
When a `prometheus-scrape-config` unit is churned, it does not get `relation_joined` events, but only `relation_created`. As such, we must also listed to that for upstream relations to ensure we correctly propagate scrape jobs downstream.