### PR TITLE
Ensure alert rules can be passed from multiple workload charms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sed-i @rbarry82 @mmanciop @balbirthomas @dstathis @Abuelodelanada
+* @sed-i @rbarry82 @mmanciop @balbirthomas @dstathis @Abuelodelanada @simskij

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 venv/
 build/
 *.charm
-
+.tox
 .coverage
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*", "pytest_operator.*"]
+module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*", "pytest_operator.*", "aiohttp.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/charm.py
+++ b/src/charm.py
@@ -198,7 +198,7 @@ class PrometheusScrapeConfigCharm(CharmBase):
         alerts = list(self._metrics_providers.alerts().values())
         alert_groups = {"groups": []}  # type: ignore
         for entry in alerts:
-            alert_groups["groups"] = alert_groups["groups"] + entry["groups"]
+            alert_groups["groups"] += entry["groups"]
 
         return {
             "scrape_jobs": configured_jobs,

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,8 +196,11 @@ class PrometheusScrapeConfigCharm(CharmBase):
             configured_jobs.append(job)
 
         alerts = list(self._metrics_providers.alerts().values())
+        alert_groups = {"groups": []}  # type: ignore
+        for entry in alerts:
+            alert_groups["groups"] = alert_groups["groups"] + entry["groups"]
 
-        return {"scrape_jobs": configured_jobs, "alert_rules": alerts[0] if alerts else []}
+        return {"scrape_jobs": configured_jobs, "alert_rules": alert_groups if alerts else []}
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,7 +200,10 @@ class PrometheusScrapeConfigCharm(CharmBase):
         for entry in alerts:
             alert_groups["groups"] = alert_groups["groups"] + entry["groups"]
 
-        return {"scrape_jobs": configured_jobs, "alert_rules": alert_groups if alerts else []}
+        return {
+            "scrape_jobs": configured_jobs,
+            "alert_rules": alert_groups if alert_groups["groups"] else {},
+        }
 
 
 if __name__ == "__main__":

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,14 +1,163 @@
+#!/usr/bin/env python3
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import logging
+from typing import List, Literal
 
-log = logging.getLogger(__name__)
+import aiohttp
+from pytest_operator.plugin import OpsTest
 
 
-async def get_unit_address(ops_test, app_name: str, unit_num: int) -> str:
-    status = await ops_test.model.get_status()  # noqa: F821
+class Prometheus:
+    """A class that represents a running instance of Prometheus."""
+
+    def __init__(self, host="localhost", port=9090):
+        """Utility to manage a Prometheus application.
+
+        Args:
+            host: Optional; host address of Prometheus application.
+            port: Optional; port on which Prometheus service is exposed.
+        """
+        self.base_url = f"http://{host}:{port}"
+
+    async def is_ready(self) -> bool:
+        """Send a GET request to check readiness.
+
+        Returns:
+          True if Prometheus is ready (returned 200 OK); False otherwise.
+        """
+        url = f"{self.base_url}/-/ready"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                return response.status == 200
+
+    async def config(self) -> str:
+        """Send a GET request to get Prometheus configuration.
+
+        Returns:
+          YAML config in string format or empty string
+        """
+        url = f"{self.base_url}/api/v1/status/config"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                result = await response.json()
+                return result["data"]["yaml"] if result["status"] == "success" else ""
+
+    async def rules(self, rules_type: Literal["alert", "record"] = None) -> list:
+        """Send a GET request to get Prometheus rules.
+
+        Args:
+          rules_type: the type of rules to fetch, or all types if not provided.
+
+        Returns:
+          Rule Groups list or empty list
+        """
+        url = f"{self.base_url}/api/v1/rules{'?type=' + rules_type if rules_type else ''}"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                result = await response.json()
+                # response looks like this:
+                # {"status":"success","data":{"groups":[]}
+                return result["data"]["groups"] if result["status"] == "success" else []
+
+    async def labels(self) -> List[str]:
+        """Send a GET request to get labels.
+
+        Returns:
+          List of labels
+        """
+        url = f"{self.base_url}/api/v1/labels"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                result = await response.json()
+                # response looks like this:
+                # {
+                #   "status": "success",
+                #   "data": [
+                #     "__name__",
+                #     "alertname",
+                #     "alertstate",
+                #     ...
+                #     "juju_application",
+                #     "juju_charm",
+                #     "juju_model",
+                #     "juju_model_uuid",
+                #     ...
+                #     "version"
+                #   ]
+                # }
+                return result["data"] if result["status"] == "success" else []
+
+    async def alerts(self) -> List[dict]:
+        """Send a GET request to get alerts.
+
+        Returns:
+          List of alerts
+        """
+        url = f"{self.base_url}/api/v1/alerts"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                result = await response.json()
+                # response looks like this:
+                #
+                # {
+                #   "status": "success",
+                #   "data": {
+                #     "alerts": [
+                #       {
+                #         "labels": {
+                #           "alertname": "AlwaysFiring",
+                #           "job": "non_existing_job",
+                #           "juju_application": "avalanche-k8s",
+                #           "juju_charm": "avalanche-k8s",
+                #           "juju_model": "remotewrite",
+                #           "juju_model_uuid": "5d2582f6-f8c9-4496-835b-675431d1fafe",
+                #           "severity": "High"
+                #         },
+                #         "annotations": {
+                #           "description": " of job non_existing_job is firing the dummy alarm.",
+                #           "summary": "Instance  dummy alarm (always firing)"
+                #         },
+                #         "state": "firing",
+                #         "activeAt": "2022-01-13T18:53:12.808550042Z",
+                #         "value": "1e+00"
+                #       }
+                #     ]
+                #   }
+                # }
+                return result["data"]["alerts"] if result["status"] == "success" else []
+
+
+async def unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> str:
+    """Find unit address for any application.
+
+    Args:
+        ops_test: pytest-operator plugin
+        app_name: string name of application
+        unit_num: integer number of a juju unit
+
+    Returns:
+        unit address as a string
+    """
+    status = await ops_test.model.get_status()
     return status["applications"][app_name]["units"][f"{app_name}/{unit_num}"]["address"]
+
+
+async def get_prometheus_rules(ops_test: OpsTest, app_name: str, unit_num: int) -> list:
+    """Fetch all Prometheus rules.
+
+    Args:
+        ops_test: pytest-operator plugin
+        app_name: string name of Prometheus application
+        unit_num: integer number of a Prometheus juju unit
+
+    Returns:
+        a list of rule groups.
+    """
+    host = await unit_address(ops_test, app_name, unit_num)
+    prometheus = Prometheus(host=host)
+    rules = await prometheus.rules()
+    return rules
 
 
 async def get_config_values(ops_test, app_name) -> dict:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,17 +16,22 @@ SPRING_NAME = "spring-music"
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, charm_under_test):
-    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME)
-    # The charm should be in blocked state if not related to anything.
-    await ops_test.model.wait_for_idle(status="blocked")
-
-
-async def test_relate(ops_test):
+async def test_dependencies(ops_test):
     await asyncio.gather(
         ops_test.model.deploy("ch:prometheus-k8s", application_name=PROM_NAME, channel="beta"),
         ops_test.model.deploy("ch:spring-music", application_name=SPRING_NAME, channel="edge"),
+        ops_test.model.deploy("ch:spring-music", application_name="spring-music2", channel="edge"),
     )
+    await ops_test.model.wait_for_idle(status="active", apps=[PROM_NAME, SPRING_NAME, "spring-music2"])
+
+
+async def test_build_and_deploy(ops_test, charm_under_test):
+    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME)
+    # The charm should be in blocked state if not related to anything.
+    await ops_test.model.wait_for_idle(status="blocked", apps=[APP_NAME])
+
+
+async def test_relate(ops_test):
     await asyncio.gather(
         ops_test.model.add_relation(PROM_NAME, APP_NAME),
         ops_test.model.add_relation(APP_NAME, SPRING_NAME),
@@ -41,9 +46,6 @@ async def test_alert_rules_exist(ops_test):
 
 async def test_multiple_workloads_alert_rules(ops_test):
     old_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
-    await ops_test.model.deploy(
-        "ch:spring-music", application_name="spring-music2", channel="edge"
-    )
     await ops_test.model.add_relation(APP_NAME, "spring-music2")
     await ops_test.model.wait_for_idle(status="active")
     new_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from helpers import get_prometheus_rules
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "cos-config"
+PROM_NAME = "prometheus"
+SPRING_NAME = "spring-music"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test, charm_under_test):
+    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME)
+    # The charm should be in blocked state if not related to anything.
+    await ops_test.model.wait_for_idle(status="blocked")
+
+
+async def test_relate(ops_test):
+    await asyncio.gather(
+        ops_test.model.deploy("ch:prometheus-k8s", application_name=PROM_NAME, channel="beta"),
+        ops_test.model.deploy("ch:spring-music", application_name=SPRING_NAME, channel="edge"),
+    )
+    await asyncio.gather(
+        ops_test.model.add_relation(PROM_NAME, APP_NAME),
+        ops_test.model.add_relation(APP_NAME, SPRING_NAME),
+    )
+    await ops_test.model.wait_for_idle(status="active")
+
+
+async def test_alert_rules_exist(ops_test):
+    rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
+    assert len(rules) > 0
+
+
+async def test_multiple_workloads_alert_rules(ops_test):
+    old_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
+    await ops_test.model.deploy(
+        "ch:spring-music", application_name="spring-music2", channel="edge"
+    )
+    await ops_test.model.add_relation(APP_NAME, "spring-music2")
+    await ops_test.model.wait_for_idle(status="active")
+    new_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
+    # Ensure that adding a second workload creates new alert rules.
+    assert len(new_rules) > len(old_rules)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -36,7 +36,7 @@ async def test_relate(ops_test):
 
 async def test_alert_rules_exist(ops_test):
     rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
-    assert len(rules) > 0
+    assert len(rules) > 0, "No alert rules are present even though spring music is related"
 
 
 async def test_multiple_workloads_alert_rules(ops_test):
@@ -47,5 +47,4 @@ async def test_multiple_workloads_alert_rules(ops_test):
     await ops_test.model.add_relation(APP_NAME, "spring-music2")
     await ops_test.model.wait_for_idle(status="active")
     new_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
-    # Ensure that adding a second workload creates new alert rules.
-    assert len(new_rules) > len(old_rules)
+    assert len(new_rules) > len(old_rules), "Additional workload instance did not add alert rules"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,7 +22,9 @@ async def test_dependencies(ops_test):
         ops_test.model.deploy("ch:spring-music", application_name=SPRING_NAME, channel="edge"),
         ops_test.model.deploy("ch:spring-music", application_name="spring-music2", channel="edge"),
     )
-    await ops_test.model.wait_for_idle(status="active", apps=[PROM_NAME, SPRING_NAME, "spring-music2"])
+    await ops_test.model.wait_for_idle(
+        status="active", apps=[PROM_NAME, SPRING_NAME, "spring-music2"]
+    )
 
 
 async def test_build_and_deploy(ops_test, charm_under_test):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -281,6 +281,8 @@ class TestCharm(unittest.TestCase):
         prom_rel_id = self.harness.add_relation("metrics-endpoint", "prometheus-k8s")
         workload_rel_id = self.harness.add_relation("configurable-scrape-jobs", "cassandra-k8s")
         self.harness.add_relation_unit(workload_rel_id, "cassandra-k8s/0")
+
+        # Set relation data on the "requires" side
         self.harness.update_relation_data(
             workload_rel_id,
             "cassandra-k8s",
@@ -310,6 +312,8 @@ class TestCharm(unittest.TestCase):
                 ),
             },
         )
+        
+        # Verify relation data on the "provides" side matches the "requires" side
         app_name = self.harness.model.app.name
         prom_rules = json.loads(
             str(self.harness.get_relation_data(prom_rel_id, app_name).get("alert_rules"))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -288,35 +288,50 @@ class TestCharm(unittest.TestCase):
                 "scrape_jobs": json.dumps(
                     [{"metrics_path": "/metrics", "static_configs": [{"targets": ["*:9500"]}]}]
                 ),
-                "alert_rules": json.dumps({
-                    "groups": [{
-                        "name": "test_alert",
-                        "rules": [{
-                            "alert": "alert",
-                            "labels": {
-                                "juju_model": "test_model",
-                                "juju_model_uuid": "test_uuid",
-                                "juju_application": "test_app",
-                                "juju_charm": "test_charm"
+                "alert_rules": json.dumps(
+                    {
+                        "groups": [
+                            {
+                                "name": "test_alert",
+                                "rules": [
+                                    {
+                                        "alert": "alert",
+                                        "labels": {
+                                            "juju_model": "test_model",
+                                            "juju_model_uuid": "test_uuid",
+                                            "juju_application": "test_app",
+                                            "juju_charm": "test_charm",
+                                        },
+                                    }
+                                ],
                             }
-                        }]
-                    }]
-                })
+                        ]
+                    }
+                ),
             },
         )
         app_name = self.harness.model.app.name
-        prom_rules = json.loads(self.harness.get_relation_data(prom_rel_id, app_name).get("alert_rules"))
-        self.assertDictEqual(prom_rules, {
-            "groups": [{
-                "name": "test_alert",
-                "rules": [{
-                    "alert": "alert",
-                    "labels": {
-                        "juju_model": "test_model",
-                        "juju_model_uuid": "test_uuid",
-                        "juju_application": "test_app",
-                        "juju_charm": "test_charm"
+        prom_rules = json.loads(
+            str(self.harness.get_relation_data(prom_rel_id, app_name).get("alert_rules"))
+        )
+        self.assertDictEqual(
+            prom_rules,
+            {
+                "groups": [
+                    {
+                        "name": "test_alert",
+                        "rules": [
+                            {
+                                "alert": "alert",
+                                "labels": {
+                                    "juju_model": "test_model",
+                                    "juju_model_uuid": "test_uuid",
+                                    "juju_application": "test_app",
+                                    "juju_charm": "test_charm",
+                                },
+                            }
+                        ],
                     }
-                }]
-            }]
-        })
+                ]
+            },
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    aiohttp
     juju
     pytest
     #pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ deps =
     aiohttp
     juju
     pytest
-    #pytest-operator
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    # There is a bug in 0.17.0 which causes test failures
+    pytest-operator==0.15.0
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration


### PR DESCRIPTION
## Issue
When multiple workload charms were related to this charm, it would only forward alert rules for one of them.


## Solution
Concatenate a list of all alert rules.


## Testing Instructions
Hook up two instances of spring-music and make sure alert rules make it in to prometheus for each of them.


## Release Notes
Fixed an issue where alert rules were not forwarded when multiple workload charms were related.
