### PR TITLE
Fix integration tests and add test for non leader unit status

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -126,7 +126,7 @@ name". However unit name is associated only with wildcard targets but
 not with fully qualified targets.
 
 Multiple jobs with different metrics paths and labels are allowed, but
-each job must be given a unique name. For example
+each job must be given a unique name:
 
 ```
 [
@@ -157,14 +157,15 @@ each job must be given a unique name. For example
 ]
 ```
 
-It is also possible to configure other scrape related parameters using
-these job specifications as described by the Prometheus
-[documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
-The permissible subset of job specific scrape configuration parameters
-supported in a `MetricsEndpointProvider` job specification are:
+**Important:** `job_name` should be a fixed string (e.g. hardcoded literal).
+For instance, if you include variable elements, like your `unit.name`, it may break
+the continuity of the metrics time series gathered by Prometheus when the leader unit
+changes (e.g. on upgrade or rescale).
 
-- `job_name`
-- `metrics_path`
+Additionally, it is also technically possible, but **strongly discouraged**, to
+configure the following scrape-related settings, which behave as described by the
+[Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config):
+
 - `static_configs`
 - `scrape_interval`
 - `scrape_timeout`
@@ -175,6 +176,11 @@ supported in a `MetricsEndpointProvider` job specification are:
 - `label_limit`
 - `label_name_length_limit`
 - `label_value_length_limit`
+
+The settings above are supported by the `prometheus_scrape` library only for the sake of
+specialized facilities like the [Prometheus Scrape Config](https://charmhub.io/prometheus-scrape-config-k8s)
+charm. Virtually no charms should use these settings, and charmers definitely **should not**
+expose them to the Juju administrator via configuration options.
 
 ## Consumer Library Usage
 
@@ -303,12 +309,14 @@ over unit relation data using the `prometheus_scrape_unit_name` and
 `scrape_jobs` and `alert_rules` keys in application relation data
 of Metrics provider charms hold eponymous information.
 
-"""
+"""  # noqa: W505
 
+import ipaddress
 import json
 import logging
 import os
 import platform
+import socket
 import subprocess
 from collections import OrderedDict
 from pathlib import Path
@@ -316,11 +324,9 @@ from typing import Dict, List, Optional, Union
 
 import yaml
 from ops.charm import CharmBase, RelationRole
-from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
 
 # The unique Charmhub library identifier, never change it
-from ops.model import ModelError
-
 LIBID = "bc84295fef5f4049878f07b131968ee2"
 
 # Increment this major API version when introducing breaking changes
@@ -328,7 +334,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 20
 
 logger = logging.getLogger(__name__)
 
@@ -915,7 +921,7 @@ class AlertRules:
         elif path.is_file():
             self.alert_groups.extend(self._from_file(path.parent, path))
         else:
-            logger.warning("path does not exist: %s", path)
+            logger.debug("Alert rules path does not exist: %s", path)
 
     def as_dict(self) -> dict:
         """Return standard alert rules file in dict representation.
@@ -1082,7 +1088,7 @@ class MetricsEndpointConsumer(Object):
         """
         alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
         for relation in self._charm.model.relations[self._relation_name]:
-            if not relation.units:
+            if not relation.units or not relation.app:
                 continue
 
             alert_rules = json.loads(relation.data[relation.app].get("alert_rules", "{}"))
@@ -1122,7 +1128,7 @@ class MetricsEndpointConsumer(Object):
             rules: a dict of alert rules
         """
         if "groups" not in rules:
-            logger.warning("No alert groups were found in relation data")
+            logger.debug("No alert groups were found in relation data")
             return None
 
         # Construct an ID based on what's in the alert rules if they have labels
@@ -1424,6 +1430,7 @@ class MetricsEndpointProvider(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         jobs=None,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
     ):
         """Construct a metrics provider for a Prometheus charm.
 
@@ -1517,6 +1524,8 @@ class MetricsEndpointProvider(Object):
                 files.  Defaults to "./prometheus_alert_rules",
                 resolved relative to the directory hosting the charm entry file.
                 The alert rules are automatically updated on charm upgrade.
+            refresh_event: an optional bound event or list of bound events which
+                will be observed to re-set scrape job data (IP address and others)
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1535,7 +1544,7 @@ class MetricsEndpointProvider(Object):
         try:
             alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
         except InvalidAlertRulePathError as e:
-            logger.warning(
+            logger.debug(
                 "Invalid Prometheus alert rules folder at %s: %s",
                 e.alert_rules_absolute_path,
                 e.message,
@@ -1555,15 +1564,35 @@ class MetricsEndpointProvider(Object):
         self.framework.observe(events.relation_joined, self._set_scrape_job_spec)
         self.framework.observe(events.relation_changed, self._set_scrape_job_spec)
 
-        # dirty fix: set the ip address when the containers start, as a workaround
-        # for not being able to lookup the pod ip
-        for container_name in charm.unit.containers:
-            self.framework.observe(
-                charm.on[container_name].pebble_ready,
-                self._set_unit_ip,
-            )
+        if not refresh_event:
+            if len(self._charm.meta.containers) == 1:
+                if "kubernetes" in self._charm.meta.series:
+                    # This is a podspec charm
+                    refresh_event = [self._charm.on.update_status]
+                else:
+                    # This is a sidecar/pebble charm
+                    container = list(self._charm.meta.containers.values())[0]
+                    refresh_event = [self._charm.on[container.name.replace("-", "_")].pebble_ready]
+            else:
+                logger.warning(
+                    "%d containers are present in metadata.yaml and "
+                    "refresh_event was not specified. Defaulting to update_status. "
+                    "Metrics IP may not be set in a timely fashion.",
+                    len(self._charm.meta.containers),
+                )
+                refresh_event = [self._charm.on.update_status]
+
+        else:
+            if not isinstance(refresh_event, list):
+                refresh_event = [refresh_event]
+
+        for ev in refresh_event:
+            self.framework.observe(ev, self._set_unit_ip)
 
         self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
+
+        # If there is no leader during relation_joined we will still need to set alert rules.
+        self.framework.observe(self._charm.on.leader_elected, self._set_scrape_job_spec)
 
     def _set_scrape_job_spec(self, event):
         """Ensure scrape target information is made available to prometheus.
@@ -1605,12 +1634,26 @@ class MetricsEndpointProvider(Object):
         event is actually needed.
         """
         for relation in self._charm.model.relations[self._relation_name]:
-            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = str(
-                self._charm.model.get_binding(relation).network.bind_address
-            )
+            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = socket.getfqdn()
             relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
                 self._charm.model.unit.name
             )
+
+    def _is_valid_unit_address(self, address: str) -> bool:
+        """Validate a unit address.
+
+        At present only IP address validation is supported, but
+        this may be extended to DNS addresses also, as needed.
+
+        Args:
+            address: a string representing a unit address
+        """
+        try:
+            _ = ipaddress.ip_address(address)
+        except ValueError:
+            return False
+
+        return True
 
     @property
     def _scrape_jobs(self) -> list:
@@ -1667,7 +1710,7 @@ class PrometheusRulesProvider(Object):
         try:
             dir_path = _resolve_dir_against_charm_path(charm, dir_path)
         except InvalidAlertRulePathError as e:
-            logger.warning(
+            logger.debug(
                 "Invalid Prometheus alert rules folder at %s: %s",
                 e.alert_rules_absolute_path,
                 e.message,
@@ -1837,13 +1880,13 @@ class MetricsEndpointAggregator(Object):
         jobs = []  # list of scrape jobs, one per relation
         for relation in self.model.relations[self._target_relation]:
             targets = self._get_targets(relation)
-            if targets:
+            if targets and relation.app:
                 jobs.append(self._static_scrape_job(targets, relation.app.name))
 
         groups = []  # list of alert rule groups, one group per relation
         for relation in self.model.relations[self._alert_rules_relation]:
             unit_rules = self._get_alert_rules(relation)
-            if unit_rules:
+            if unit_rules and relation.app:
                 appname = relation.app.name
                 rules = self._label_alert_rules(unit_rules, appname)
                 group = {"name": self._group_name(appname), "rules": rules}
@@ -2238,7 +2281,7 @@ class PromqlTransformer:
         try:
             return self._exec(args)
         except Exception as e:
-            logger.debug('Applying the expression failed: "{}", falling back to the original', e)
+            logger.debug('Applying the expression failed: "%s", falling back to the original', e)
             return expression
 
     def _get_transformer_path(self) -> Optional[Path]:
@@ -2246,13 +2289,13 @@ class PromqlTransformer:
         arch = "amd64" if arch == "x86_64" else arch
         res = "promql-transform-{}".format(arch)
         try:
-            path = self._charm.model.resources.fetch(res)
-            os.chmod(path, 0o777)
+            path = Path(res).resolve()
+            path.chmod(0o777)
             return path
         except NotImplementedError:
             logger.debug("System lacks support for chmod")
-        except (NameError, ModelError):
-            logger.debug('No resource available for the platform "{}"'.format(arch))
+        except FileNotFoundError:
+            logger.debug('Could not locate promql transform at: "{}"'.format(res))
         return None
 
     def _exec(self, cmd):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 [tool.mypy]
 pretty = true
 python_version = 3.8
-mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/integration"
+mypy_path = "./src:./lib"
 follow_imports = "normal"
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,4 @@ follow_imports = "silent"
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*", "pytest_operator.*", "aiohttp.*"]
+module = ["ops.*", "json.*", "pytest.*", "pytest_operator.*", "aiohttp.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-git+https://github.com/canonical/operator/#egg=ops
+ops

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -19,7 +19,7 @@ ZINC_NAME = "zinc"
 async def test_dependencies(ops_test):
     await asyncio.gather(
         ops_test.model.deploy(
-            "ch:prometheus-k8s", application_name=PROM_NAME, channel="beta", trust=True
+            "ch:prometheus-k8s", application_name=PROM_NAME, channel="edge", trust=True
         ),
         ops_test.model.deploy("ch:zinc-k8s", application_name=ZINC_NAME, channel="edge"),
         ops_test.model.deploy("ch:zinc-k8s", application_name="zinc2", channel="edge"),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ async def test_dependencies(ops_test):
         ops_test.model.deploy("ch:zinc-k8s", application_name=ZINC_NAME, channel="edge"),
         ops_test.model.deploy("ch:zinc-k8s", application_name="zinc2", channel="edge"),
     )
-    await ops_test.model.wait_for_idle(status="active", apps=[PROM_NAME, ZINC_NAME, "zinc2"])
+    await ops_test.model.wait_for_idle(status="active")
 
 
 async def test_build_and_deploy(ops_test, charm_under_test):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,9 +22,7 @@ async def test_dependencies(ops_test):
         ops_test.model.deploy("ch:zinc-k8s", application_name=ZINC_NAME, channel="edge"),
         ops_test.model.deploy("ch:zinc-k8s", application_name="zinc2", channel="edge"),
     )
-    await ops_test.model.wait_for_idle(
-        status="active", apps=[PROM_NAME, ZINC_NAME, "zinc2"]
-    )
+    await ops_test.model.wait_for_idle(status="active", apps=[PROM_NAME, ZINC_NAME, "zinc2"])
 
 
 async def test_build_and_deploy(ops_test, charm_under_test):
@@ -35,8 +33,12 @@ async def test_build_and_deploy(ops_test, charm_under_test):
 
 async def test_relate(ops_test):
     await asyncio.gather(
-        ops_test.model.add_relation(f"{PROM_NAME}:metrics-endpoint", f"{APP_NAME}:metrics-endpoint"),
-        ops_test.model.add_relation(f"{APP_NAME}:configurable-scrape-jobs", f"{ZINC_NAME}:metrics-endpoint"),
+        ops_test.model.add_relation(
+            f"{PROM_NAME}:metrics-endpoint", f"{APP_NAME}:metrics-endpoint"
+        ),
+        ops_test.model.add_relation(
+            f"{APP_NAME}:configurable-scrape-jobs", f"{ZINC_NAME}:metrics-endpoint"
+        ),
     )
     await ops_test.model.wait_for_idle(status="active")
 
@@ -53,11 +55,10 @@ async def test_multiple_workloads_alert_rules(ops_test):
     new_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
     assert len(new_rules) > len(old_rules), "Additional workload instance did not add alert rules"
 
+
 async def test_non_leader_units_set_waiting_status(ops_test):
     await ops_test.model.applications[APP_NAME].scale(scale=2)
-    await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[APP_NAME].units) == 2
-    )
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 2)
     await ops_test.model.wait_for_idle()
     statuses = []
     for unit in ops_test.model.applications[APP_NAME].units:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -12,18 +12,18 @@ logger = logging.getLogger(__name__)
 
 APP_NAME = "cos-config"
 PROM_NAME = "prometheus"
-SPRING_NAME = "spring-music"
+ZINC_NAME = "zinc"
 
 
 @pytest.mark.abort_on_fail
 async def test_dependencies(ops_test):
     await asyncio.gather(
         ops_test.model.deploy("ch:prometheus-k8s", application_name=PROM_NAME, channel="beta"),
-        ops_test.model.deploy("ch:spring-music", application_name=SPRING_NAME, channel="edge"),
-        ops_test.model.deploy("ch:spring-music", application_name="spring-music2", channel="edge"),
+        ops_test.model.deploy("ch:zinc-k8s", application_name=ZINC_NAME, channel="edge"),
+        ops_test.model.deploy("ch:zinc-k8s", application_name="zinc2", channel="edge"),
     )
     await ops_test.model.wait_for_idle(
-        status="active", apps=[PROM_NAME, SPRING_NAME, "spring-music2"]
+        status="active", apps=[PROM_NAME, ZINC_NAME, "zinc2"]
     )
 
 
@@ -35,20 +35,20 @@ async def test_build_and_deploy(ops_test, charm_under_test):
 
 async def test_relate(ops_test):
     await asyncio.gather(
-        ops_test.model.add_relation(PROM_NAME, APP_NAME),
-        ops_test.model.add_relation(APP_NAME, SPRING_NAME),
+        ops_test.model.add_relation(f"{PROM_NAME}:metrics-endpoint", f"{APP_NAME}:metrics-endpoint"),
+        ops_test.model.add_relation(f"{APP_NAME}:configurable-scrape-jobs", f"{ZINC_NAME}:metrics-endpoint"),
     )
     await ops_test.model.wait_for_idle(status="active")
 
 
 async def test_alert_rules_exist(ops_test):
     rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
-    assert len(rules) > 0, "No alert rules are present even though spring music is related"
+    assert len(rules) > 0, "No alert rules are present even though zinc is related"
 
 
 async def test_multiple_workloads_alert_rules(ops_test):
     old_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
-    await ops_test.model.add_relation(APP_NAME, "spring-music2")
+    await ops_test.model.add_relation(APP_NAME, "zinc2")
     await ops_test.model.wait_for_idle(status="active")
     new_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
     assert len(new_rules) > len(old_rules), "Additional workload instance did not add alert rules"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -52,3 +52,16 @@ async def test_multiple_workloads_alert_rules(ops_test):
     await ops_test.model.wait_for_idle(status="active")
     new_rules = await get_prometheus_rules(ops_test=ops_test, app_name=PROM_NAME, unit_num=0)
     assert len(new_rules) > len(old_rules), "Additional workload instance did not add alert rules"
+
+async def test_non_leader_units_set_waiting_status(ops_test):
+    await ops_test.model.applications[APP_NAME].scale(scale=2)
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[APP_NAME].units) == 2
+    )
+    await ops_test.model.wait_for_idle()
+    statuses = []
+    for unit in ops_test.model.applications[APP_NAME].units:
+        statuses.append(unit.workload_status)
+    assert len(statuses) == 2
+    assert "active" in statuses
+    assert "waiting" in statuses

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,7 +18,9 @@ ZINC_NAME = "zinc"
 @pytest.mark.abort_on_fail
 async def test_dependencies(ops_test):
     await asyncio.gather(
-        ops_test.model.deploy("ch:prometheus-k8s", application_name=PROM_NAME, channel="beta"),
+        ops_test.model.deploy(
+            "ch:prometheus-k8s", application_name=PROM_NAME, channel="beta", trust=True
+        ),
         ops_test.model.deploy("ch:zinc-k8s", application_name=ZINC_NAME, channel="edge"),
         ops_test.model.deploy("ch:zinc-k8s", application_name="zinc2", channel="edge"),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,6 @@ deps =
     aiohttp
     juju
     pytest
-    # There is a bug in 0.17.0 which causes test failures
-    pytest-operator==0.15.0
+    pytest-operator
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration

--- a/tox.ini
+++ b/tox.ini
@@ -60,18 +60,9 @@ deps =
     -r{toxinidir}/requirements.txt
     mypy
     types-PyYAML
-    pytest
-    pytest-operator
-    juju
-    types-setuptools
     types-toml
-    # pip-check-reqs does not yet work with recent pip
-    pip-check-reqs
-    pip<=21.1.3
 commands =
-    pip-missing-reqs {toxinidir}/src --requirements-file={toxinidir}/requirements.txt
-    pip-extra-reqs {toxinidir}/src --requirements-file={toxinidir}/requirements.txt
-    mypy {[vars]all_path} {posargs}
+    mypy {[vars]src_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
## Issue
This PR 
- Fixes failure in integration tests because asyncio mode was not set to auto
- Migrates integration tests from Spring Music charm to Zinc k8s charm
- Updates the version of pytest operator used
- Adds a new integration test to check that non leader units set waiting status
- Fix failures in static analysis due to recent changes in mypy
- Upgrade to the latest Prometheus charm library

closes #9 

## Solution
NA


## Context
NA


## Testing Instructions
NA


## Release Notes
- Integration tests fixed and extended
