### PR TITLE
Remove outdated comment

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -64,9 +64,7 @@ class PrometheusScrapeConfigCharm(CharmBase):
         )
 
         # When a new consumer of the metrics-endpoint relation is related,
-        # pass it all the current scrape jobs. We register to both the relation
-        # being created and joined, because relation_created is not reliably sent
-        # over unit recreation.
+        # pass it all the current scrape jobs.
         self.framework.observe(
             self.on[self._metrics_consumer_relation_name].relation_created,
             self._update_new_metrics_consumer,


### PR DESCRIPTION
## Issue
There was an old comment that does not make sense anymore. The situation referenced in the comment will not matter because the relations will updated on both config-changed and upgrade-charm and also the relations use fqdn.


## Solution
Delete the comment


## Testing Instructions
None


## Release Notes
None
