### PR TITLE
Observe `start` too

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -72,8 +72,14 @@ class PrometheusScrapeConfigCharm(CharmBase):
 
         # manages configuration changes for this charm
         self.framework.observe(self.on.config_changed, self._update_all_metrics_consumers)
+        
         # Ensure we refresh scrape jobs on charm upgrade
         self.framework.observe(self.on.upgrade_charm, self._update_all_metrics_consumers)
+        
+        # Sometimes a `stop` event is followed by a `start` event with nothing in between
+        # https://bugs.launchpad.net/juju/+bug/2015566
+        self.framework.observe(self.on.start, self._update_all_metrics_consumers)
+        
         # Initial charm setup
         self.framework.observe(self.on.install, self._on_install)
 


### PR DESCRIPTION
## Issue
During load test, the charm received a `StopContainer`, didn't get a `config-changed`, and was stuck in `maintenance`.

https://bugs.launchpad.net/juju/+bug/2015566


## Solution
Observe `start` as well, just in case.
(Already impl'd for scrape-target: https://github.com/canonical/prometheus-scrape-target-k8s-operator/pull/25)


## Context
NTA.


## Testing Instructions
Load test at high load.


## Release Notes
Observe `start` too.
