### PR TITLE
Fix relabel key name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ options:
   relabel_configs:
     description: YAML string formatted scrape target relabeling configuration.
     type: string
-  metrics_relabel_configs:
+  metric_relabel_configs:
     description: YAML string formatted metrics relabeling configuration.
     type: string
   sample_limit:

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ through the 'metrics-endpoint' relation using the
 import json
 import logging
 
+import yaml
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from ops.charm import CharmBase
 from ops.main import main
@@ -118,7 +119,11 @@ class PrometheusScrapeConfigCharm(CharmBase):
         charm. The scrape jobs (including associated alert rules)
         are returned.
         """
-        config = self.model.config.items()
+        yaml_keys = ["relabel_configs", "metric_relabel_configs"]
+        config = {k: v for k, v in self.model.config.items() if k not in yaml_keys}
+        for key in yaml_keys:
+            if as_yaml := self.model.config.get(key):
+                config[key] = yaml.safe_load(as_yaml)
 
         configured_jobs = []
         for job in self._metrics_providers.jobs():


### PR DESCRIPTION
## Issue
Before this PR, during the `config.yaml` had the wrong key: `metrics_relabel_configs` (`metrics` in plural). [The correct key](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) is `metric_relabel_configs` (`metric`, in singular).

As a result, we were generating an invalid config that prometheus was dropping.

In addition, the yaml string wasn't parsed into a python object.

## Solution
- Remove the stray `s`.
- `yaml.safe_load` the yaml configs.

In tandem with:
- https://github.com/canonical/prometheus-k8s-operator/pull/599

## Testing
```
$ juju config sc metric_relabel_configs="$(cat <<EOF
- source_labels: ["__name__"]
  regex: "go_gc_.+"
  action: "drop"
EOF
)"
```