### PR TITLE
[skip ci] chore: update CODEOWNERS to use observability team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @sed-i @rbarry82 @mmanciop @balbirthomas @dstathis @Abuelodelanada @simskij

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @abuelodelanada @dstathis @IbraAoad @lucabello @mmkay @pietropasotti @sed-i @simskij
+*       @canonical/Observability


### PR DESCRIPTION
[skip ci] chore: update CODEOWNERS to use observability team