### PR TITLE
fix: use 'ruff check', reorder imports for ruff 0.6.x

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,10 +7,11 @@ import json
 import typing
 import unittest
 
-from charm import PrometheusScrapeConfigCharm
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
+
+from charm import PrometheusScrapeConfigCharm
 
 
 class TestCharm(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -42,7 +42,7 @@ deps =
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip *.svg
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-charm]


### PR DESCRIPTION

## Issue
Currently, the CI fails during linting

## Solution
Update the tox.ini to use `ruff check`
Reorder the imports to satisfying ruff 0.6.x

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
