### PR TITLE
feat: add support for disabling alert rules forwarding

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,5 +33,5 @@ options:
     type: int
   forward_alert_rules:
     description: Toggle forwarding of alert rules.
-    type: bool
+    type: boolean
     default: true

--- a/config.yaml
+++ b/config.yaml
@@ -31,3 +31,7 @@ options:
   label_value_length_limit:
     description: Maximum length of label value (0=unlimited)
     type: int
+  forward_alert_rules:
+    description: Toggle forwarding of alert rules.
+    type: bool
+    default: true

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 49
+LIBPATCH = 50
 
 PYDEPS = ["cosl"]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,6 +34,7 @@ class PrometheusScrapeConfigCharm(CharmBase):
 
         self._metrics_provider_relation_name = "configurable-scrape-jobs"
         self._metrics_consumer_relation_name = "metrics-endpoint"
+        self._forward_alert_rules = self.config["forward_alert_rules"]
 
         # The metrics consumer object in this charm also acts as the metrics provider for other metrics
         # consumer charms related with this charm, hence we label the metrics consumer object in this charm
@@ -132,8 +133,9 @@ class PrometheusScrapeConfigCharm(CharmBase):
 
         alerts = list(self._metrics_providers.alerts.values())
         alert_groups = {"groups": []}  # type: ignore
-        for entry in alerts:
-            alert_groups["groups"] += entry["groups"]
+        if self._forward_alert_rules:
+            for entry in alerts:
+                alert_groups["groups"] += entry["groups"]
 
         return {
             "scrape_jobs": configured_jobs,

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ through the 'metrics-endpoint' relation using the
 
 import json
 import logging
+from typing import cast
 
 import yaml
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
@@ -34,7 +35,7 @@ class PrometheusScrapeConfigCharm(CharmBase):
 
         self._metrics_provider_relation_name = "configurable-scrape-jobs"
         self._metrics_consumer_relation_name = "metrics-endpoint"
-        self._forward_alert_rules = self.config["forward_alert_rules"]
+        self._forward_alert_rules = cast(bool, self.config["forward_alert_rules"])
 
         # The metrics consumer object in this charm also acts as the metrics provider for other metrics
         # consumer charms related with this charm, hence we label the metrics consumer object in this charm


### PR DESCRIPTION
## Issue
This PR is part of allowing users to disable a charm's alert rules.

## Solution
Introduce a config flag similar to https://github.com/canonical/grafana-agent-operator/pull/252